### PR TITLE
 Setting up redux toolkit with graphql

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+    
+};
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@apollo/client": "^3.11.8",
         "@emotion/cache": "^11.13.1",
         "@mui/material-nextjs": "^6.1.4",
+        "@reduxjs/toolkit": "^2.3.0",
         "apollo-server-micro": "^3.13.0",
         "graphql": "^16.9.0",
         "graphql-tag": "^2.12.6",
@@ -1045,6 +1046,30 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.3.0.tgz",
+      "integrity": "sha512-WC7Yd6cNGfHx8zf+iu+Q1UPTfEcXhQ+ATi7CV1hlrSAaQBdlPzg7Ww/wJHNQem7qG9rxmWoFCDCPubSvFObGzA==",
+      "license": "MIT",
+      "dependencies": {
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -2058,6 +2083,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -2963,6 +2998,21 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
@@ -2986,6 +3036,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.8",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@apollo/client": "^3.11.8",
     "@emotion/cache": "^11.13.1",
     "@mui/material-nextjs": "^6.1.4",
+    "@reduxjs/toolkit": "^2.3.0",
     "apollo-server-micro": "^3.13.0",
     "graphql": "^16.9.0",
     "graphql-tag": "^2.12.6",

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -1,0 +1,29 @@
+import { gql } from "@apollo/client";
+
+export const GET_RESPONSIBILITIES = gql`
+  query {
+    getResponsibilities {
+      data {
+        name
+      }
+    }
+  }
+`;
+export const GET_PRODUCT_TAG = gql`
+  query {
+    getProductTags {
+      data {
+        name
+      }
+    }
+  }
+`;
+export const GET_PRODUCTS = gql`
+  query {
+    getProducts {
+      data {
+        name
+      }
+    }
+  }
+`;

--- a/src/lib/apolloclient.ts
+++ b/src/lib/apolloclient.ts
@@ -1,0 +1,28 @@
+import {
+  ApolloClient,
+  InMemoryCache,
+  HttpLink,
+  ApolloLink,
+} from "@apollo/client";
+import { setContext } from "@apollo/client/link/context";
+
+const httpLink = new HttpLink({
+  uri: process.env.NEXT_PUBLIC_API_URL,
+});
+
+const authLink = setContext((_, { headers }) => {
+  const token = localStorage.getItem("token");
+  return {
+    headers: {
+      ...headers,
+      authorization: token ? `Bearer ${token}` : "",
+    },
+  };
+});
+
+const apolloClient = new ApolloClient({
+  link: ApolloLink.from([authLink, httpLink]),
+  cache: new InMemoryCache(),
+});
+
+export default apolloClient;

--- a/src/store/api.ts
+++ b/src/store/api.ts
@@ -1,0 +1,56 @@
+// store/apis.ts
+import { createAction, createAsyncThunk } from '@reduxjs/toolkit';
+import { GET_RESPONSIBILITIES, GET_PRODUCT_TAG, GET_PRODUCTS } from '../graphql/queries';
+import apolloClient from '../lib/apolloclient';
+
+
+class Api {
+
+  resetAll = createAction('resetAll');
+
+  responsibilities = createAsyncThunk(
+    'fetchResponsibilities',
+    async (_, { rejectWithValue }) => {
+      try {
+        const response = await apolloClient.query({
+          query: GET_RESPONSIBILITIES,
+        });
+        return response.data.getResponsibilities.data;
+      } catch (error: any) {
+        return rejectWithValue({ error: error?.message });
+      }
+    }
+  );
+
+  // Fetch product tags query
+  productTags = createAsyncThunk(
+    'fetchProductTags',
+    async (_, { rejectWithValue }) => {
+      try {
+        const response = await apolloClient.query({
+          query: GET_PRODUCT_TAG,
+        });
+        return response.data.getProductTags.data;
+      } catch (error: any) {
+        return rejectWithValue({ error: error?.message });
+      }
+    }
+  );
+
+  // Fetch products query
+  products = createAsyncThunk(
+    'fetchProducts',
+    async (_, { rejectWithValue }) => {
+      try {
+        const response = await apolloClient.query({
+          query: GET_PRODUCTS,
+        });
+        return response.data.getProducts.data;
+      } catch (error: any) {
+        return rejectWithValue({ error: error?.message });
+      }
+    }
+  );
+}
+const apis = new Api();
+export default apis;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,14 @@
+import { configureStore } from "@reduxjs/toolkit";
+import responsibilities from "./reducer/responsibilities";
+import product from "./reducer/product";
+import productsTags from "./reducer/productsTags";
+
+const store = configureStore({
+  reducer: {
+    responsibilities,
+    product,
+    productsTags,
+  },
+});
+
+export default store;

--- a/src/store/reducer/product.ts
+++ b/src/store/reducer/product.ts
@@ -1,0 +1,44 @@
+// store/reducers/products.ts
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import apis from "../api";
+
+const productsSlice = createSlice({
+  name: "products",
+  initialState: {
+    data: [],
+    loading: false,
+    error: false,
+    message: "",
+    success: false,
+  },
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(apis.products.pending, (state) => {
+        state.loading = true;
+        state.error = false;
+        state.success = false;
+      })
+      .addCase(apis.products.fulfilled, (state, action: PayloadAction<[]>) => {
+        state.loading = false;
+        state.success = true;
+        state.error = false;
+        state.data = action.payload;
+
+      })
+      .addCase(apis.products.rejected, (state, action: PayloadAction<any>) => {
+        state.loading = false;
+        state.success = false;
+        state.error = true;
+        state.message = action.payload?.error || "Something went wrong";
+      })
+      .addCase(apis.resetAll, (state) => {
+        state.loading = false;
+        state.error = false;
+        state.success = false;
+        state.data = [];
+      });
+  },
+});
+
+export default productsSlice.reducer;

--- a/src/store/reducer/productsTags.ts
+++ b/src/store/reducer/productsTags.ts
@@ -1,0 +1,44 @@
+// store/reducers/products.ts
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import apis from "../api";
+
+const productsTagsSlice = createSlice({
+  name: "productsTags",
+  initialState: {
+    data: [],
+    loading: false,
+    error: false,
+    message: "",
+    success: false,
+  },
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(apis.productTags.pending, (state) => {
+        state.loading = true;
+        state.error = false;
+        state.success = false;
+      })
+      .addCase(apis.productTags.fulfilled, (state, action: PayloadAction<[]>) => {
+        state.loading = false;
+        state.success = true;
+        state.error = false;
+        state.data = action.payload;
+
+      })
+      .addCase(apis.productTags.rejected, (state, action: PayloadAction<any>) => {
+        state.loading = false;
+        state.success = false;
+        state.error = true;
+        state.message = action.payload?.error || "Something went wrong";
+      })
+      .addCase(apis.resetAll, (state) => {
+        state.loading = false;
+        state.error = false;
+        state.success = false;
+        state.data = [];
+      });
+  },
+});
+
+export default productsTagsSlice.reducer;

--- a/src/store/reducer/responsibilities.ts
+++ b/src/store/reducer/responsibilities.ts
@@ -1,0 +1,43 @@
+// store/reducers/responsibilities.ts
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import apis from "../api";
+
+const responsibilitiesSlice = createSlice({
+  name: "responsibilities",
+  initialState: {
+    data: [],
+    loading: false,
+    error: false,
+    success: false,
+    message: "",
+  },
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(apis.responsibilities.pending, (state) => {
+        state.loading = true;
+        state.error = false;
+        state.success = false;
+      })
+      .addCase(
+        apis.responsibilities.fulfilled,
+        (state, action: PayloadAction<[]>) => {
+          state.loading = false;
+          state.data = action.payload;
+          state.success = true;
+          state.error = false;
+        }
+      )
+      .addCase(
+        apis.responsibilities.rejected,
+        (state, action: PayloadAction<any>) => {
+          state.loading = false;
+          state.error = true;
+          state.message = action.payload?.error || "Something went wrong";
+          state.success = false;
+        }
+      );
+  },
+});
+
+export default responsibilitiesSlice.reducer;

--- a/src/store/types.d.ts
+++ b/src/store/types.d.ts
@@ -1,0 +1,4 @@
+import store from ".";
+
+type RootState = ReturnType<typeof store.getState>;
+type AppDispatch = typeof store.dispatch;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",
+    "types": ["@types/node"],
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",


### PR DESCRIPTION

## What this PR do
This PR introduces the integration of **Redux Toolkit** with **GraphQL** to manage the application's state. The configuration includes:

- Setting up the **Redux store** with reducers for `responsibilities`, `products`, and `productTags`.
- Creating asynchronous actions using `createAsyncThunk` for fetching data via **GraphQL queries**.
- Implementing slices for each entity (`responsibilities`, `products`, `productTags`) to handle state management, including loading, success, and error states.
- Integrating **Apollo Client** to interact with the GraphQL API and managing queries within Redux actions.

## Key Changes:
- Added `responsibilities`, `products`, and `productTags` slices to handle the corresponding data.
- Configured Apollo Client for making GraphQL requests.
- Set up a `store` with the necessary reducers and middleware.

This setup ensures efficient state management with GraphQL in the application, improving performance and maintainability.
